### PR TITLE
Switch to one term per year

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'combine_popolo_memberships', '~> 0.2.0', git: "https://github.com/everypolitician/combine_popolo_memberships.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/everypolitician/combine_popolo_memberships.git
+  revision: 0a18a0defb11cf08f59f7f6cdc8de898227cbe89
+  specs:
+    combine_popolo_memberships (0.2.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -46,6 +52,7 @@ PLATFORMS
 
 DEPENDENCIES
   colorize
+  combine_popolo_memberships (~> 0.2.0)!
   execjs
   fuzzy_match
   nokogiri
@@ -53,3 +60,9 @@ DEPENDENCIES
   pry
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
The terms of members of the Chamber of Deputies are four years long,
but half of these terms are offset from the others by two years.
We've decided it will be easier to manage this is we say that a "term"
in EveryPolitician's data corresponds to a calendar year.

These "terms" thus correspond to the yearly sessions of the congress,
from 3rd of March to the 30th of November each year.  The existing
scraper used the official session number as a term ID, and this commit
extends that, with 2015 => 133, 2016 => 134, etc.

This scraper doesn't use the scraped page archiver yet, so I've left
in the mandate_start and mandate_end properties of each membership.

The morph.io database should be deleted before running this new
version of the scraper, since there were previously some entries which
had:

  term: 133
  start_date: 2015-12-10
  end_date:
  mandate_start: 2015-12-10
  mandate_end: 2019-12-09

I don't think this membership should be counted as part of term 133,
since the mandate began after the end of session 133.

However, since this scraper is currently running under tmtmtmtm's
morph.io account, we can achieve the same end result by running this
scraper on the everypolitician-scrapers morph.io account.